### PR TITLE
fix logging desc

### DIFF
--- a/docs/getting-start/deploy-you-own-okchain-testnet.md
+++ b/docs/getting-start/deploy-you-own-okchain-testnet.md
@@ -168,7 +168,7 @@ Each `./build/nodeN` directory is mounted to the `/okchaind` directory in each c
 
 ### Logging
 
-Logs are saved under each `./build/nodeN/okchaind/okchain.log`. You can also watch logs
+Logs are saved under each `./build/nodeN/okchaind/okchaind.log`. You can also watch logs
 directly via Docker, for example:
 
 ```


### PR DESCRIPTION
OKChaind's log path is ". / build/nodeN/okchaind/okchaind.log"